### PR TITLE
Update indigo web CSS to 0.1.3

### DIFF
--- a/modules/custom/indigo/styles/akoma-ntoso.css
+++ b/modules/custom/indigo/styles/akoma-ntoso.css
@@ -112,9 +112,20 @@
     font-weight: bold; }
   .akoma-ntoso .akn-remark {
     font-style: italic; }
+  .akoma-ntoso img {
+    max-width: 100%; }
   .akoma-ntoso .coverpage {
     text-align: center;
     margin-bottom: 1.6em; }
+    .akoma-ntoso .coverpage .notice-list {
+      margin: 0px;
+      padding: 0px; }
+      .akoma-ntoso .coverpage .notice-list li {
+        list-style: none; }
+    .akoma-ntoso .coverpage .assent-date,
+    .akoma-ntoso .coverpage .commencement-date {
+      margin-bottom: 0.8em;
+      font-weight: bold; }
     .akoma-ntoso .coverpage .amendment-list {
       margin-top: 1.6em;
       padding: 0px; }
@@ -122,10 +133,6 @@
       list-style: none;
       margin-bottom: 0.8em;
       font-style: italic; }
-    .akoma-ntoso .coverpage .assent-date,
-    .akoma-ntoso .coverpage .commencement-date {
-      margin-bottom: 0.8em;
-      font-weight: bold; }
 
 /*
  * Tables


### PR DESCRIPTION
In particular, adds styling for items on the auto-generated coverpage.